### PR TITLE
Ruff: Ignore generated rpc py files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ pytest = "^8.3.2"
 
 [tool.ruff]
 line-length=120
+exclude=[
+    "kaspad/rpc_pb2.py",
+    "kaspad/rpc_pb2_grpc.py"
+]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Ruff format makes changes in possible sensitive places in generated files, better to just ignore them