### PR TITLE
Calculate difficulty from the compact representation bits

### DIFF
--- a/endpoints/get_blocks.py
+++ b/endpoints/get_blocks.py
@@ -9,6 +9,7 @@ from sqlalchemy import select, exists, func
 
 from dbsession import async_session
 from endpoints.get_virtual_chain_blue_score import current_blue_score_data
+from helper.difficulty_calculation import bits_to_difficulty
 from helper.mining_address import get_miner_payload_from_block, retrieve_miner_info_from_payload
 from models.Block import Block
 from models.BlockParent import BlockParent
@@ -215,7 +216,7 @@ def map_block_from_db(block, is_chain_block, parents, children, transaction_ids,
         "transactions": transactions,
         "verboseData": {
             "hash": block.hash,
-            "difficulty": block.difficulty,
+            "difficulty": bits_to_difficulty(block.bits),
             "selectedParentHash": block.selected_parent_hash,
             "transactionIds": transaction_ids,
             "blueScore": block.blue_score,

--- a/helper/difficulty_calculation.py
+++ b/helper/difficulty_calculation.py
@@ -1,0 +1,21 @@
+def from_compact_target_bits(bits):
+    # Translation of https://github.com/kaspanet/rusty-kaspa/blob/master/math/src/lib.rs
+    unshifted_expt = bits >> 24
+    if unshifted_expt <= 3:
+        mant = (bits & 0xFFFFFF) >> (8 * (3 - unshifted_expt))
+        expt = 0
+    else:
+        mant = bits & 0xFFFFFF
+        expt = 8 * (unshifted_expt - 3)
+    if mant > 0x7FFFFF:
+        return 0
+    else:
+        return mant << expt
+
+
+def bits_to_difficulty(bits):
+    # https://github.com/kaspanet/rusty-kaspa/blob/master/consensus/core/src/config/constants.rs:
+    max_target = 2**255 - 1
+    # https://github.com/kaspanet/rusty-kaspa/blob/master/rpc/service/src/converter/consensus.rs:
+    target = from_compact_target_bits(bits)
+    return max_target / target if target != 0 else float("inf")

--- a/models/Block.py
+++ b/models/Block.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Float, BigInteger, SmallInteger
+from sqlalchemy import Column, BigInteger, SmallInteger
 
 from dbsession import Base
 from models.type_decorators.HexColumn import HexColumn
@@ -10,7 +10,6 @@ class Block(Base):
     __tablename__ = "blocks"
     hash = Column(HexColumn, primary_key=True)
     accepted_id_merkle_root = Column(HexColumn)
-    difficulty = Column(Float)
     merge_set_blues_hashes = Column(HexArrayColumn)
     merge_set_reds_hashes = Column(HexArrayColumn)
     selected_parent_hash = Column(HexColumn)


### PR DESCRIPTION
Calculate difficulty from the compact representation bits, allowing us to drop difficulty from the db. 
Having both difficulty and bits, like we have today, is redundant and the bits column are half the size of difficulty.