### PR TITLE
add `currentBlueScore` and `dbCheck` to `/info/health`

### DIFF
--- a/endpoints/get_health.py
+++ b/endpoints/get_health.py
@@ -1,15 +1,15 @@
 # encoding: utf-8
 import hashlib
 from datetime import datetime, timedelta
-from typing import List
+from typing import List, Dict
 
-from fastapi import HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
 
 from dbsession import async_session
 from models.Transaction import Transaction
 from server import app, kaspad_client
+from endpoints.get_virtual_chain_blue_score import current_blue_score_data
 
 
 class KaspadResponse(BaseModel):
@@ -22,26 +22,47 @@ class KaspadResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     kaspadServers: List[KaspadResponse]
+    currentBlueScore: int = None
+    dbCheck: Dict[str, str]  # report database status
 
 
 @app.get("/info/health", response_model=HealthResponse, tags=["Kaspa network info"])
 async def health_state():
     """
-    Returns the current hashrate for Kaspa network in TH/s.
+    Checks health by verifying node sync status, the recency of the latest block in
+    the database, and returns each node's status, version, and the current blue score.
+
+    If the database check fails, `dbCheck` will show an "error" status and relevant
+    message. If the latest block is older than 10 minutes, it will indicate an outdated
+    status. Otherwise, the status is marked as "valid".
     """
     await kaspad_client.initialize_all()
 
     kaspads = []
 
-    async with async_session() as s:
-        last_block_time = (
-            await s.execute(select(Transaction.block_time).limit(1).order_by(Transaction.block_time.desc()))
-        ).scalar()
+    # dbCheck status
+    db_check_status = {"status": "valid", "message": "Database is up-to-date"}
 
-    time_diff = datetime.now() - datetime.fromtimestamp(last_block_time / 1000)
+    # check the recency of the latest transaction's block time in the database
+    try:
+        async with async_session() as s:
+            last_block_time = (
+                await s.execute(
+                    select(Transaction.block_time)
+                    .limit(1)
+                    .order_by(Transaction.block_time.desc())
+                )
+            ).scalar()
 
-    if time_diff > timedelta(minutes=10):
-        raise HTTPException(status_code=500, detail="Transactions not up to date")
+        time_diff = datetime.now() - datetime.fromtimestamp(last_block_time / 1000)
+
+        if time_diff > timedelta(minutes=10):
+            db_check_status = {
+                "status": "error",
+                "message": "Block age older than 10 minutes",
+            }
+    except Exception:
+        db_check_status = {"status": "error", "message": "Database unavailable"}
 
     for i, kaspad_info in enumerate(kaspad_client.kaspads):
         kaspads.append(
@@ -54,4 +75,10 @@ async def health_state():
             }
         )
 
-    return {"kaspadServers": kaspads}
+    current_blue_score = current_blue_score_data.get("blue_score")
+
+    return {
+        "kaspadServers": kaspads,
+        "currentBlueScore": current_blue_score,
+        "dbCheck": db_check_status,
+    }

--- a/endpoints/get_health.py
+++ b/endpoints/get_health.py
@@ -9,6 +9,7 @@ from dbsession import async_session
 from models.Block import Block
 from server import app, kaspad_client
 from endpoints.get_virtual_chain_blue_score import current_blue_score_data
+from fastapi import HTTPException
 
 
 class KaspadResponse(BaseModel):
@@ -22,7 +23,7 @@ class KaspadResponse(BaseModel):
 class DBCheckStatus(BaseModel):
     status: str
     message: str
-    blueScoreDB: int = None  # holds db blue score if available
+    blueScoreDB: int = None
 
 
 class HealthResponse(BaseModel):
@@ -34,27 +35,25 @@ class HealthResponse(BaseModel):
 @app.get("/info/health", response_model=HealthResponse, tags=["Kaspa network info"])
 async def health_state():
     """
-    Checks the health of the node and database by comparing the latest blue scores from
-    both sources. The response includes the sync status, version, and blue score of the node,
-    as well as the latest blue score from the database. If the database blue score lags behind
-    the node's blue score by 1,000 or more, an "error" status is returned.
+    Checks node and database health by comparing blue score and sync status.
+    Returns health details or 503 if the database lags by 1,000+ blocks or a node is not synced.
     """
     await kaspad_client.initialize_all()
 
     kaspads = []
     db_check_status = DBCheckStatus(status="valid", message="Database blue score is within range")
 
-    # latest blue score from the node once
+    # latest blue score node
     current_blue_score_node = current_blue_score_data.get("blue_score")
 
-    # latest blue score from the database
+    # latest blue score db
     try:
         async with async_session() as s:
             last_blue_score_db = (
                 await s.execute(select(Block.blue_score).order_by(Block.blue_score.desc()).limit(1))
             ).scalar()
 
-        # check node and database blue scores
+        # check node and db blue scores
         if last_blue_score_db is None:
             db_check_status = DBCheckStatus(status="error", message="No blue score in database")
         elif current_blue_score_node is not None and abs(current_blue_score_node - last_blue_score_db) >= 1000:
@@ -63,7 +62,6 @@ async def health_state():
                 message=f"Blue score difference exceeds 1000 blocks (Node: {current_blue_score_node}, DB: {last_blue_score_db})",
             )
         else:
-            # If blue score difference is within 1000 blocks, mark as valid
             db_check_status = DBCheckStatus(
                 status="valid",
                 message="Database blue score is within range",
@@ -72,6 +70,26 @@ async def health_state():
 
     except Exception:
         db_check_status = DBCheckStatus(status="error", message="Database unavailable")
+
+    # 503 if db or node health is invalid
+    if db_check_status.status == "error" or not all(kaspad_info.is_synced for kaspad_info in kaspad_client.kaspads):
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "kaspadServers": [
+                    {
+                        "isSynced": kaspad_info.is_synced,
+                        "isUtxoIndexed": kaspad_info.is_utxo_indexed,
+                        "p2pId": hashlib.sha256(kaspad_info.p2p_id.encode()).hexdigest(),
+                        "kaspadHost": f"KASPAD_HOST_{i + 1}",
+                        "serverVersion": kaspad_info.server_version,
+                    }
+                    for i, kaspad_info in enumerate(kaspad_client.kaspads)
+                ],
+                "currentBlueScoreNode": current_blue_score_node,
+                "currentDBStatus": db_check_status,
+            },
+        )
 
     for i, kaspad_info in enumerate(kaspad_client.kaspads):
         kaspads.append(

--- a/endpoints/get_health.py
+++ b/endpoints/get_health.py
@@ -1,13 +1,12 @@
 # encoding: utf-8
 import hashlib
-from datetime import datetime, timedelta
-from typing import List, Dict
+from typing import List
 
 from pydantic import BaseModel
 from sqlalchemy import select
 
 from dbsession import async_session
-from models.Transaction import Transaction
+from models.Block import Block
 from server import app, kaspad_client
 from endpoints.get_virtual_chain_blue_score import current_blue_score_data
 
@@ -20,49 +19,59 @@ class KaspadResponse(BaseModel):
     p2pId: str = "1231312"
 
 
+class DBCheckStatus(BaseModel):
+    status: str
+    message: str
+    blueScoreDB: int = None  # holds db blue score if available
+
+
 class HealthResponse(BaseModel):
     kaspadServers: List[KaspadResponse]
-    currentBlueScore: int = None
-    dbCheck: Dict[str, str]  # report database status
+    currentBlueScoreNode: int = None
+    currentDBStatus: DBCheckStatus
 
 
 @app.get("/info/health", response_model=HealthResponse, tags=["Kaspa network info"])
 async def health_state():
     """
-    Checks health by verifying node sync status, the recency of the latest block in
-    the database, and returns each node's status, version, and the current blue score.
-
-    If the database check fails, `dbCheck` will show an "error" status and relevant
-    message. If the latest block is older than 10 minutes, it will indicate an outdated
-    status. Otherwise, the status is marked as "valid".
+    Checks the health of the node and database by comparing the latest blue scores from
+    both sources. The response includes the sync status, version, and blue score of the node,
+    as well as the latest blue score from the database. If the database blue score lags behind
+    the node's blue score by 1,000 or more, an "error" status is returned.
     """
     await kaspad_client.initialize_all()
 
     kaspads = []
+    db_check_status = DBCheckStatus(status="valid", message="Database blue score is within range")
 
-    # dbCheck status
-    db_check_status = {"status": "valid", "message": "Database is up-to-date"}
+    # latest blue score from the node once
+    current_blue_score_node = current_blue_score_data.get("blue_score")
 
-    # check the recency of the latest transaction's block time in the database
+    # latest blue score from the database
     try:
         async with async_session() as s:
-            last_block_time = (
-                await s.execute(
-                    select(Transaction.block_time)
-                    .limit(1)
-                    .order_by(Transaction.block_time.desc())
-                )
+            last_blue_score_db = (
+                await s.execute(select(Block.blue_score).order_by(Block.blue_score.desc()).limit(1))
             ).scalar()
 
-        time_diff = datetime.now() - datetime.fromtimestamp(last_block_time / 1000)
+        # check node and database blue scores
+        if last_blue_score_db is None:
+            db_check_status = DBCheckStatus(status="error", message="No blue score in database")
+        elif current_blue_score_node is not None and abs(current_blue_score_node - last_blue_score_db) >= 1000:
+            db_check_status = DBCheckStatus(
+                status="error",
+                message=f"Blue score difference exceeds 1000 blocks (Node: {current_blue_score_node}, DB: {last_blue_score_db})",
+            )
+        else:
+            # If blue score difference is within 1000 blocks, mark as valid
+            db_check_status = DBCheckStatus(
+                status="valid",
+                message="Database blue score is within range",
+                blueScoreDB=last_blue_score_db,
+            )
 
-        if time_diff > timedelta(minutes=10):
-            db_check_status = {
-                "status": "error",
-                "message": "Block age older than 10 minutes",
-            }
     except Exception:
-        db_check_status = {"status": "error", "message": "Database unavailable"}
+        db_check_status = DBCheckStatus(status="error", message="Database unavailable")
 
     for i, kaspad_info in enumerate(kaspad_client.kaspads):
         kaspads.append(
@@ -75,10 +84,8 @@ async def health_state():
             }
         )
 
-    current_blue_score = current_blue_score_data.get("blue_score")
-
     return {
         "kaspadServers": kaspads,
-        "currentBlueScore": current_blue_score,
-        "dbCheck": db_check_status,
+        "currentBlueScoreNode": current_blue_score_node,
+        "currentDBStatus": db_check_status,
     }


### PR DESCRIPTION
- added `currentBlueScore` field to `/info/health` endpoint
- retrieves latest blue score from `get_virtual_chain_blue_score.py` via `getSinkBlueScoreRequest` RPC (which is updating every 5 seconds) with the most recent value retrieved from the node
- holds last known blue score if RPC call fails
- added `dbCheck`
  - ~~Valid: Indicates database is up-to-date if the latest block is within 10 minutes~~
  - ~~Error - Block Age: Reports "error" with message "Block age older than 10 minutes" if the last block timestamp exceeds 10 minutes~~
  - ~~Error - Database Unavailable: Reports "error" with message "Database unavailable" if the database connection fails~~
- previously: compares timestamp of latest tx block in the database with the current time
- now: gets latest blue scores from both node and database; if blue score difference is within 1000 blocks, valid.
  

Fix for: https://github.com/kaspa-ng/kaspa-rest-server/issues/22