### PR TITLE
Limit address/../transaction-count to 10k by default

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,5 +1,7 @@
 import os
 
+DISABLE_LIMITS = os.getenv("DISABLE_LIMITS", "false").lower() == "true"
+
 NETWORK_TYPE = os.getenv("NETWORK_TYPE", "mainnet").lower()
 
 match NETWORK_TYPE:


### PR DESCRIPTION
Avoids the heavy load of counting million row addresses (exchanges, large miners).
Also adds a new boolean field to the response 'limit_exceeded', and Cache-Control ttl values.
The limit can be turned off by settings DISABLE_LIMITS env var to "true".