### PR TITLE
Previous outpoint preresolved

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -2,6 +2,7 @@ import os
 
 DISABLE_LIMITS = os.getenv("DISABLE_LIMITS", "false").lower() == "true"
 USE_SCRIPT_FOR_ADDRESS = os.getenv("USE_SCRIPT_FOR_ADDRESS", "false").lower() == "true"
+PREV_OUT_RESOLVED = os.getenv("PREV_OUT_RESOLVED", "false").lower() == "true"
 
 TX_SEARCH_ID_LIMIT = int(os.getenv("TX_SEARCH_ID_LIMIT", "1000"))
 TX_SEARCH_BS_LIMIT = int(os.getenv("TX_SEARCH_BS_LIMIT", "100"))

--- a/endpoints/get_transactions.py
+++ b/endpoints/get_transactions.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-
+import asyncio
 import logging
 from collections import defaultdict
 from enum import Enum
@@ -317,64 +317,12 @@ async def search_for_transactions(
                 )
                 tx_acceptances = {row.accepting_block_hash: row for row in tx_acceptances.all()}
 
-            tx_blocks = await session_blocks.execute(
-                select(BlockTransaction).filter(BlockTransaction.transaction_id.in_(transaction_ids))
-            )
-            tx_blocks_dict = defaultdict(list)
-            for row in tx_blocks.scalars().all():
-                tx_blocks_dict[row.transaction_id].append(row.block_hash)
-            tx_blocks = tx_blocks_dict
-
-            if not fields or "inputs" in fields:
-                if resolve_previous_outpoints in ["light", "full"]:
-                    tx_inputs = await session.execute(
-                        select(TransactionInput, TransactionOutput)
-                        .outerjoin(
-                            TransactionOutput,
-                            (TransactionOutput.transaction_id == TransactionInput.previous_outpoint_hash)
-                            & (TransactionOutput.index == TransactionInput.previous_outpoint_index),
-                        )
-                        .filter(TransactionInput.transaction_id.in_(transaction_ids))
-                        .order_by(TransactionInput.transaction_id, TransactionInput.index)
-                    )
-                    tx_inputs_dict = defaultdict(list)
-                    for tx_input, tx_prev_output in tx_inputs.all():
-                        if tx_prev_output:
-                            tx_input.previous_outpoint_amount = tx_prev_output.amount
-                            tx_input.previous_outpoint_address = tx_prev_output.script_public_key_address
-                            if resolve_previous_outpoints == "full":
-                                tx_input.previous_outpoint_resolved = tx_prev_output
-                        else:
-                            tx_input.previous_outpoint_amount = None
-                            tx_input.previous_outpoint_address = None
-                            if resolve_previous_outpoints == "full":
-                                tx_input.previous_outpoint_resolved = None
-                        tx_inputs_dict[tx_input.transaction_id].append(tx_input)
-                else:
-                    tx_inputs = await session.execute(
-                        select(TransactionInput)
-                        .filter(TransactionInput.transaction_id.in_(transaction_ids))
-                        .order_by(TransactionInput.transaction_id, TransactionInput.index)
-                    )
-                    tx_inputs_dict = defaultdict(list)
-                    for tx_input in tx_inputs.scalars().all():
-                        tx_inputs_dict[tx_input.transaction_id].append(tx_input)
-                tx_inputs = tx_inputs_dict
-            else:
-                tx_inputs = {}
-
-            if not fields or "outputs" in fields:
-                tx_outputs = await session.execute(
-                    select(TransactionOutput)
-                    .filter(TransactionOutput.transaction_id.in_(transaction_ids))
-                    .order_by(TransactionOutput.transaction_id, TransactionOutput.index)
-                )
-                tx_outputs_dict = defaultdict(list)
-                for tx_output in tx_outputs.scalars().all():
-                    tx_outputs_dict[tx_output.transaction_id].append(tx_output)
-                tx_outputs = tx_outputs_dict
-            else:
-                tx_outputs = {}
+            async_tasks = [
+                get_tx_blocks_from_db(transaction_ids, session_blocks),
+                get_tx_inputs_from_db(fields, resolve_previous_outpoints, transaction_ids, session),
+                get_tx_outputs_from_db(fields, transaction_ids, session),
+            ]
+            tx_blocks, tx_inputs, tx_outputs = await asyncio.gather(*async_tasks)
 
     block_cache = {}
     results = []
@@ -414,6 +362,70 @@ async def search_for_transactions(
         )
         results.append(result)
     return results
+
+
+async def get_tx_blocks_from_db(transaction_ids, session_blocks):
+    tx_blocks = await session_blocks.execute(
+        select(BlockTransaction).filter(BlockTransaction.transaction_id.in_(transaction_ids))
+    )
+    tx_blocks_dict = defaultdict(list)
+    for row in tx_blocks.scalars().all():
+        tx_blocks_dict[row.transaction_id].append(row.block_hash)
+    return tx_blocks_dict
+
+
+async def get_tx_inputs_from_db(fields, resolve_previous_outpoints, transaction_ids, session):
+    tx_inputs_dict = defaultdict(list)
+    if fields and "inputs" not in fields:
+        return tx_inputs_dict
+
+    if resolve_previous_outpoints in ["light", "full"]:
+        tx_inputs = await session.execute(
+            select(TransactionInput, TransactionOutput)
+            .outerjoin(
+                TransactionOutput,
+                (TransactionOutput.transaction_id == TransactionInput.previous_outpoint_hash)
+                & (TransactionOutput.index == TransactionInput.previous_outpoint_index),
+            )
+            .filter(TransactionInput.transaction_id.in_(transaction_ids))
+            .order_by(TransactionInput.transaction_id, TransactionInput.index)
+        )
+        for tx_input, tx_prev_output in tx_inputs.all():
+            if tx_prev_output:
+                tx_input.previous_outpoint_amount = tx_prev_output.amount
+                tx_input.previous_outpoint_address = tx_prev_output.script_public_key_address
+                if resolve_previous_outpoints == "full":
+                    tx_input.previous_outpoint_resolved = tx_prev_output
+            else:
+                tx_input.previous_outpoint_amount = None
+                tx_input.previous_outpoint_address = None
+                if resolve_previous_outpoints == "full":
+                    tx_input.previous_outpoint_resolved = None
+            tx_inputs_dict[tx_input.transaction_id].append(tx_input)
+    else:
+        tx_inputs = await session.execute(
+            select(TransactionInput)
+            .filter(TransactionInput.transaction_id.in_(transaction_ids))
+            .order_by(TransactionInput.transaction_id, TransactionInput.index)
+        )
+        for tx_input in tx_inputs.scalars().all():
+            tx_inputs_dict[tx_input.transaction_id].append(tx_input)
+    return tx_inputs_dict
+
+
+async def get_tx_outputs_from_db(fields, transaction_ids, session):
+    tx_outputs_dict = defaultdict(list)
+    if fields and "outputs" not in fields:
+        return tx_outputs_dict
+
+    tx_outputs = await session.execute(
+        select(TransactionOutput)
+        .filter(TransactionOutput.transaction_id.in_(transaction_ids))
+        .order_by(TransactionOutput.transaction_id, TransactionOutput.index)
+    )
+    for tx_output in tx_outputs.scalars().all():
+        tx_outputs_dict[tx_output.transaction_id].append(tx_output)
+    return tx_outputs_dict
 
 
 async def get_transaction_from_kaspad(block_hashes, transactionId, includeInputs, includeOutputs):

--- a/endpoints/get_transactions.py
+++ b/endpoints/get_transactions.py
@@ -218,8 +218,8 @@ async def get_transaction(
 
                     for tx_in, tx_prev_output in tx_inputs:
                         if tx_prev_output:
+                            tx_in.previous_outpoint_script = tx_prev_output.script_public_key
                             tx_in.previous_outpoint_amount = tx_prev_output.amount
-                            tx_in.previous_outpoint_address = tx_prev_output.script_public_key_address
                             if resolve_previous_outpoints == "full":
                                 tx_in.previous_outpoint_resolved = tx_prev_output
 
@@ -397,13 +397,13 @@ async def get_tx_inputs_from_db(fields, resolve_previous_outpoints, transaction_
             )
             for tx_input, tx_prev_output in tx_inputs.all():
                 if tx_prev_output:
+                    tx_input.previous_outpoint_script = tx_prev_output.script_public_key
                     tx_input.previous_outpoint_amount = tx_prev_output.amount
-                    tx_input.previous_outpoint_address = tx_prev_output.script_public_key_address
                     if resolve_previous_outpoints == "full":
                         tx_input.previous_outpoint_resolved = tx_prev_output
                 else:
+                    tx_input.previous_outpoint_script = None
                     tx_input.previous_outpoint_amount = None
-                    tx_input.previous_outpoint_address = None
                     if resolve_previous_outpoints == "full":
                         tx_input.previous_outpoint_resolved = None
                 tx_inputs_dict[tx_input.transaction_id].append(tx_input)

--- a/endpoints/get_transactions.py
+++ b/endpoints/get_transactions.py
@@ -11,7 +11,7 @@ from sqlalchemy import exists
 from sqlalchemy.future import select
 from starlette.responses import Response
 
-from constants import TX_SEARCH_ID_LIMIT, TX_SEARCH_BS_LIMIT
+from constants import TX_SEARCH_ID_LIMIT, TX_SEARCH_BS_LIMIT, PREV_OUT_RESOLVED
 from dbsession import async_session, async_session_blocks
 from endpoints import filter_fields, sql_db_only
 from helper.utils import add_cache_control
@@ -384,7 +384,7 @@ async def get_tx_inputs_from_db(fields, resolve_previous_outpoints, transaction_
         return tx_inputs_dict
 
     async with async_session() as session:
-        if resolve_previous_outpoints in ["light", "full"]:
+        if resolve_previous_outpoints == "light" and not PREV_OUT_RESOLVED or resolve_previous_outpoints == "full":
             tx_inputs = await session.execute(
                 select(TransactionInput, TransactionOutput)
                 .outerjoin(

--- a/models/Transaction.py
+++ b/models/Transaction.py
@@ -45,3 +45,11 @@ class TransactionInput(Base):
     previous_outpoint_index = Column(SmallInteger)
     signature_script = Column(HexColumn)
     sig_op_count = Column(SmallInteger)
+    previous_outpoint_script = Column(HexColumn)
+    previous_outpoint_amount = Column(BigInteger)
+
+    @property
+    def previous_outpoint_address(self):
+        if self.previous_outpoint_script:
+            return to_address(ADDRESS_PREFIX, self.previous_outpoint_script)
+        return None


### PR DESCRIPTION
Builds on #60 
This PR adds support for using pre-resolved inputs (supported in indexer >=v1.2.0) instead of query-time input resolve if the env var PREV_OUT_RESOLVED=true. No breaking changes.

The following migration must be applied to pre-resolve all already existing inputs (before applying PREV_OUT_RESOLVED=true):
Make sure to stop the indexer first!
```sql
CREATE TABLE transactions_inputs_resolved AS
SELECT
    i.transaction_id,
    i.index,
    i.previous_outpoint_hash,
    i.previous_outpoint_index,
    i.signature_script,
    i.sig_op_count,
    i.block_time,
    o.script_public_key AS previous_outpoint_script,
    o.amount AS previous_outpoint_amount
FROM transactions_inputs i
LEFT JOIN transactions_outputs o
    ON i.previous_outpoint_hash = o.transaction_id
    AND i.previous_outpoint_index = o.index;

DROP TABLE transactions_inputs;
ALTER TABLE transactions_inputs_resolved RENAME TO transactions_inputs;
ALTER TABLE transactions_inputs ADD PRIMARY KEY (transaction_id, index);
ANALYZE transactions_inputs;
```