### PR TITLE
/virtual-chain - redundant copies of block rows are discarded

### DIFF
--- a/endpoints/get_virtual_chain.py
+++ b/endpoints/get_virtual_chain.py
@@ -87,6 +87,7 @@ async def get_virtual_chain_transactions(
                 Block.daa_score,
                 Block.timestamp,
             )
+            .distinct()
             .select_from(Block)
             .join(TransactionAcceptance, Block.hash == TransactionAcceptance.block_hash)
             .where(between(Block.blue_score, blue_score_gte, blue_score_lt - 1))


### PR DESCRIPTION
Because the block is mapped to transactions, the SQL response contains copies of the block info row for each transaction in the block.

At the end of the API call, a response is generated as a list of blocks, where the blocks are copied for each row from the result of this SQL query. 

This results in unnecessary extra traffic and decreased api performance.