### PR TITLE
Limit utxos

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ poetry run gunicorn -b 0.0.0.0:8000 -w 4 -k uvicorn.workers.UvicornWorker main:a
 * PREV_OUT_RESOLVED - If true tx inputs are assumed populated with sender address, see indexer doc (default: false)
 * TX_SEARCH_ID_LIMIT - adjust the maximum number of transactionIds for transactions/search (default: 1000)
 * TX_SEARCH_BS_LIMIT - adjust the maximum blue score range for transactions/search (default: 100)
+* SCRIPTS_UTXOS_LIMIT - addresses exceeding this UTXO count will return an empty list from /addresses/{address}/utxos (default: 10000)
 * VSPC_REQUEST - If true enables /info/get-vscp-from-block (default: false)
 * TRANSACTION_COUNT - If true (a prepopulated) transactions_counts table will be used to provide /transactions/count/{day_or_month} (default: false)
 * ADDRESSES_ACTIVE_COUNT - If true (a prepopulated) scripts_active_counts table will be used to provide /addresses/active/count/{day_or_month} (default: false)

--- a/constants.py
+++ b/constants.py
@@ -13,6 +13,7 @@ TRANSACTION_COUNT = os.getenv("TRANSACTION_COUNT", "false").lower() == "true"
 ADDRESSES_ACTIVE_COUNT = os.getenv("ADDRESSES_ACTIVE_COUNT", "false").lower() == "true"
 HASHRATE_HISTORY = os.getenv("HASHRATE_HISTORY", "false").lower() == "true"
 ADDRESS_RANKINGS = os.getenv("ADDRESS_RANKINGS", "false").lower() == "true"
+SCRIPTS_UTXOS_LIMIT = int(os.getenv("SCRIPTS_UTXOS_LIMIT", "10000"))
 
 NETWORK_TYPE = os.getenv("NETWORK_TYPE", "mainnet").lower()
 BPS = int(os.getenv("BPS", "10"))

--- a/endpoints/get_utxos.py
+++ b/endpoints/get_utxos.py
@@ -75,6 +75,7 @@ async def get_utxos_for_address(
 
     over_limit = await _get_over_limit_addresses([kaspaAddress])
     if over_limit:
+        _logger.info("UTXO count over limit for address: %s", kaspaAddress)
         raise HTTPException(
             status_code=413,
             detail=f"Address UTXO count exceeds the limit of {SCRIPTS_UTXOS_LIMIT}",
@@ -118,6 +119,8 @@ async def get_utxos_for_addresses(body: UtxoRequest):
             raise HTTPException(status_code=400, detail=f"Invalid address: {kaspaAddress}")
 
     over_limit = await _get_over_limit_addresses(body.addresses)
+    if over_limit:
+        _logger.info("UTXO count over limit for addresses: %s", over_limit)
     allowed = [a for a in body.addresses if a not in over_limit]
     if not allowed:
         return []

--- a/endpoints/get_utxos.py
+++ b/endpoints/get_utxos.py
@@ -66,7 +66,7 @@ async def get_utxos_for_address(
     """
     Lists all open utxo for a given kaspa address.
 
-    Returns HTTP 413 if the address holds too many UTXOs.
+    Returns an empty list if the address holds too many UTXOs.
     """
     try:
         to_script(kaspaAddress)
@@ -76,10 +76,8 @@ async def get_utxos_for_address(
     over_limit = await _get_over_limit_addresses([kaspaAddress])
     if over_limit:
         _logger.info("UTXO count over limit for address: %s", kaspaAddress)
-        raise HTTPException(
-            status_code=413,
-            detail=f"Address UTXO count exceeds the limit of {SCRIPTS_UTXOS_LIMIT}",
-        )
+        response.headers["Cache-Control"] = "public, max-age=60"
+        return []
 
     utxos = await get_utxos([kaspaAddress])
 
@@ -87,15 +85,7 @@ async def get_utxos_for_address(
     if utxo_count > 1_000:
         _logger.info("High UTXO count for address %s: %d", kaspaAddress, utxo_count)
 
-    ttl = 8
-    if utxo_count > 100_000:
-        ttl = 3600
-    elif utxo_count > 10_000:
-        ttl = 600
-    elif utxo_count > 1_000:
-        ttl = 20
-
-    response.headers["Cache-Control"] = f"public, max-age={ttl}"
+    response.headers["Cache-Control"] = f"public, max-age={_utxo_count_to_ttl(utxo_count)}"
     return (utxo for utxo in utxos if utxo["address"] == kaspaAddress)
 
 
@@ -144,6 +134,7 @@ async def get_utxos_for_addresses(body: UtxoRequest):
     openapi_extra={"strict_query_params": True},
 )
 async def get_utxo_count_for_address(
+    response: Response,
     kaspaAddress: str = Path(description=f"Kaspa address as string e.g. {ADDRESS_EXAMPLE}", regex=REGEX_KASPA_ADDRESS),
 ):
     """
@@ -154,14 +145,25 @@ async def get_utxo_count_for_address(
     except ValueError:
         raise HTTPException(status_code=400, detail=f"Invalid address: {kaspaAddress}")
 
-    count = await _get_utxo_count_from_table(kaspaAddress)
-    if count is None:
+    utxo_count = await _get_utxo_count_from_table(kaspaAddress)
+    if utxo_count is None:
         utxos = await get_utxos([kaspaAddress])
-        count = len([u for u in utxos if u["address"] == kaspaAddress])
-    if count > 1_000:
-        _logger.info("High UTXO count for address %s: %d", kaspaAddress, count)
+        utxo_count = len([u for u in utxos if u["address"] == kaspaAddress])
+    if utxo_count > 1_000:
+        _logger.info("High UTXO count for address %s: %d", kaspaAddress, utxo_count)
 
-    return {"count": count}
+    response.headers["Cache-Control"] = f"public, max-age={_utxo_count_to_ttl(utxo_count)}"
+    return {"count": utxo_count}
+
+
+def _utxo_count_to_ttl(count: int) -> int:
+    if count > 100_000:
+        return 3600
+    if count > 10_000:
+        return 600
+    if count > 1_000:
+        return 60
+    return 8
 
 
 async def get_utxos(addresses):

--- a/endpoints/get_utxos.py
+++ b/endpoints/get_utxos.py
@@ -83,12 +83,16 @@ async def get_utxos_for_address(
 
     utxos = await get_utxos([kaspaAddress])
 
+    utxo_count = len(utxos)
+    if utxo_count > 1_000:
+        _logger.info("High UTXO count for address %s: %d", kaspaAddress, utxo_count)
+
     ttl = 8
-    if len(utxos) > 100_000:
+    if utxo_count > 100_000:
         ttl = 3600
-    elif len(utxos) > 10_000:
+    elif utxo_count > 10_000:
         ttl = 600
-    elif len(utxos) > 1_000:
+    elif utxo_count > 1_000:
         ttl = 20
 
     response.headers["Cache-Control"] = f"public, max-age={ttl}"
@@ -125,7 +129,12 @@ async def get_utxos_for_addresses(body: UtxoRequest):
     if not allowed:
         return []
 
-    return await get_utxos(allowed)
+    utxos = await get_utxos(allowed)
+    for addr in allowed:
+        addr_count = len([u for u in utxos if u["address"] == addr])
+        if addr_count > 1_000:
+            _logger.info("High UTXO count for address %s: %d", addr, addr_count)
+    return utxos
 
 
 @app.get(
@@ -149,6 +158,8 @@ async def get_utxo_count_for_address(
     if count is None:
         utxos = await get_utxos([kaspaAddress])
         count = len([u for u in utxos if u["address"] == kaspaAddress])
+    if count > 1_000:
+        _logger.info("High UTXO count for address %s: %d", kaspaAddress, count)
 
     return {"count": count}
 

--- a/endpoints/get_utxos.py
+++ b/endpoints/get_utxos.py
@@ -248,14 +248,10 @@ async def _get_utxo_count_from_table(kaspaAddress: str) -> int | None:
 
         if USE_SCRIPT_FOR_ADDRESS:
             result = await s.execute(
-                select(ScriptUtxoCount.count).where(
-                    ScriptUtxoCount.script_public_key == to_script(kaspaAddress)
-                )
+                select(ScriptUtxoCount.count).where(ScriptUtxoCount.script_public_key == to_script(kaspaAddress))
             )
         else:
             result = await s.execute(
-                select(ScriptUtxoCount.count).where(
-                    ScriptUtxoCount.script_public_key_address == kaspaAddress
-                )
+                select(ScriptUtxoCount.count).where(ScriptUtxoCount.script_public_key_address == kaspaAddress)
             )
         return result.scalar()

--- a/endpoints/get_utxos.py
+++ b/endpoints/get_utxos.py
@@ -1,16 +1,25 @@
 # encoding: utf-8
+import logging
+import os
 import re
 from asyncio import wait_for
 from typing import List
 
 from fastapi import Path, HTTPException
-from kaspa_script_address import to_script
+from kaspa_script_address import to_script, to_address
 from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.future import select
 from starlette.responses import Response
 
-from constants import REGEX_KASPA_ADDRESS, ADDRESS_EXAMPLE
+from constants import REGEX_KASPA_ADDRESS, ADDRESS_EXAMPLE, ADDRESS_PREFIX, SCRIPTS_UTXOS_LIMIT, USE_SCRIPT_FOR_ADDRESS
+from dbsession import async_session
 from kaspad.KaspadRpcClient import kaspad_rpc_client
+from models.ScriptUtxoCount import ScriptUtxoCount
 from server import app, kaspad_client
+
+_logger = logging.getLogger(__name__)
+_utxo_count_table_exists: bool | None = None
 
 
 class OutpointModel(BaseModel):
@@ -46,12 +55,21 @@ async def get_utxos_for_address(
     kaspaAddress: str = Path(description=f"Kaspa address as string e.g. {ADDRESS_EXAMPLE}", regex=REGEX_KASPA_ADDRESS),
 ):
     """
-    Lists all open utxo for a given kaspa address
+    Lists all open utxo for a given kaspa address.
+
+    Returns HTTP 507 if the address holds more than `SCRIPTS_UTXOS_LIMIT` UTXOs.
     """
     try:
         to_script(kaspaAddress)
     except ValueError:
         raise HTTPException(status_code=400, detail=f"Invalid address: {kaspaAddress}")
+
+    over_limit = await _get_over_limit_addresses([kaspaAddress])
+    if over_limit:
+        raise HTTPException(
+            status_code=507,
+            detail=f"Address UTXO count exceeds the limit of {SCRIPTS_UTXOS_LIMIT}",
+        )
 
     utxos = await get_utxos([kaspaAddress])
 
@@ -79,7 +97,9 @@ class UtxoRequest(BaseModel):
 )
 async def get_utxos_for_addresses(body: UtxoRequest):
     """
-    Lists all open utxo for a given kaspa address
+    Lists all open utxo for a given list of kaspa addresses.
+
+    Addresses that hold more than `SCRIPTS_UTXOS_LIMIT` UTXOs are silently omitted from the response.
     """
     if body.addresses is None:
         return []
@@ -92,7 +112,12 @@ async def get_utxos_for_addresses(body: UtxoRequest):
         except ValueError:
             raise HTTPException(status_code=400, detail=f"Invalid address: {kaspaAddress}")
 
-    return await get_utxos(body.addresses)
+    over_limit = await _get_over_limit_addresses(body.addresses)
+    allowed = [a for a in body.addresses if a not in over_limit]
+    if not allowed:
+        return []
+
+    return await get_utxos(allowed)
 
 
 async def get_utxos(addresses):
@@ -112,3 +137,50 @@ async def get_utxos(addresses):
         utxos = resp["getUtxosByAddressesResponse"]
 
     return utxos["entries"]
+
+
+async def _get_over_limit_addresses(addresses: list[str]) -> set[str]:
+    """
+    Returns the subset of *addresses* whose UTXO count exceeds SCRIPTS_UTXOS_LIMIT
+    according to the script_utxo_counts table.  Returns an empty set when the table
+    does not exist or the primary DB is not configured.
+    """
+    if not os.getenv("SQL_URI"):
+        return set()
+
+    global _utxo_count_table_exists
+    async with async_session() as s:
+        if _utxo_count_table_exists is None:
+            result = await s.execute(
+                text(
+                    "SELECT EXISTS ("
+                    "SELECT FROM information_schema.tables "
+                    "WHERE table_schema = 'public' AND table_name = 'script_utxo_counts'"
+                    ");"
+                )
+            )
+            _utxo_count_table_exists = result.scalar()
+            if _utxo_count_table_exists:
+                _logger.info("script_utxo_counts helper table detected")
+            else:
+                _logger.info("script_utxo_counts helper table NOT found – UTXO count limiting disabled")
+
+        if not _utxo_count_table_exists:
+            return set()
+
+        if USE_SCRIPT_FOR_ADDRESS:
+            result = await s.execute(
+                select(ScriptUtxoCount.script_public_key).where(
+                    ScriptUtxoCount.script_public_key.in_([to_script(addr) for addr in addresses]),
+                    ScriptUtxoCount.count > SCRIPTS_UTXOS_LIMIT,
+                )
+            )
+            return {to_address(ADDRESS_PREFIX, spk) for spk in result.scalars()}
+        else:
+            result = await s.execute(
+                select(ScriptUtxoCount.script_public_key_address).where(
+                    ScriptUtxoCount.script_public_key_address.in_(addresses),
+                    ScriptUtxoCount.count > SCRIPTS_UTXOS_LIMIT,
+                )
+            )
+            return set(result.scalars())

--- a/endpoints/get_utxos.py
+++ b/endpoints/get_utxos.py
@@ -19,6 +19,7 @@ from models.ScriptUtxoCount import ScriptUtxoCount
 from server import app, kaspad_client
 
 _logger = logging.getLogger(__name__)
+IS_SQL_DB_CONFIGURED = os.getenv("SQL_URI") is not None
 _utxo_count_table_exists: bool | None = None
 
 
@@ -65,7 +66,7 @@ async def get_utxos_for_address(
     """
     Lists all open utxo for a given kaspa address.
 
-    Returns HTTP 507 if the address holds too many UTXOs.
+    Returns HTTP 413 if the address holds too many UTXOs.
     """
     try:
         to_script(kaspaAddress)
@@ -75,7 +76,7 @@ async def get_utxos_for_address(
     over_limit = await _get_over_limit_addresses([kaspaAddress])
     if over_limit:
         raise HTTPException(
-            status_code=507,
+            status_code=413,
             detail=f"Address UTXO count exceeds the limit of {SCRIPTS_UTXOS_LIMIT}",
         )
 
@@ -194,7 +195,7 @@ async def _get_over_limit_addresses(addresses: list[str]) -> set[str]:
     according to the script_utxo_counts table.  Returns an empty set when the table
     does not exist or the primary DB is not configured.
     """
-    if not os.getenv("SQL_URI"):
+    if not IS_SQL_DB_CONFIGURED:
         return set()
 
     async with async_session() as s:
@@ -224,7 +225,7 @@ async def _get_utxo_count_from_table(kaspaAddress: str) -> int | None:
     Returns the UTXO count for *kaspaAddress* from the helper table,
     or None if the table is absent or has no row for the address.
     """
-    if not os.getenv("SQL_URI"):
+    if not IS_SQL_DB_CONFIGURED:
         return None
 
     async with async_session() as s:

--- a/endpoints/get_utxos.py
+++ b/endpoints/get_utxos.py
@@ -44,6 +44,14 @@ class UtxoResponse(BaseModel):
     utxoEntry: UtxoModel
 
 
+class UtxoRequest(BaseModel):
+    addresses: list[str] = [ADDRESS_EXAMPLE]
+
+
+class UtxoCountResponse(BaseModel):
+    count: int
+
+
 @app.get(
     "/addresses/{kaspaAddress}/utxos",
     response_model=List[UtxoResponse],
@@ -57,7 +65,7 @@ async def get_utxos_for_address(
     """
     Lists all open utxo for a given kaspa address.
 
-    Returns HTTP 507 if the address holds more than `SCRIPTS_UTXOS_LIMIT` UTXOs.
+    Returns HTTP 507 if the address holds too many UTXOs.
     """
     try:
         to_script(kaspaAddress)
@@ -85,10 +93,6 @@ async def get_utxos_for_address(
     return (utxo for utxo in utxos if utxo["address"] == kaspaAddress)
 
 
-class UtxoRequest(BaseModel):
-    addresses: list[str] = [ADDRESS_EXAMPLE]
-
-
 @app.post(
     "/addresses/utxos",
     response_model=List[UtxoResponse],
@@ -99,7 +103,7 @@ async def get_utxos_for_addresses(body: UtxoRequest):
     """
     Lists all open utxo for a given list of kaspa addresses.
 
-    Addresses that hold more than `SCRIPTS_UTXOS_LIMIT` UTXOs are silently omitted from the response.
+    Addresses that hold too many UTXOs are silently omitted from the response.
     """
     if body.addresses is None:
         return []
@@ -118,6 +122,31 @@ async def get_utxos_for_addresses(body: UtxoRequest):
         return []
 
     return await get_utxos(allowed)
+
+
+@app.get(
+    "/addresses/{kaspaAddress}/utxos/count",
+    response_model=UtxoCountResponse,
+    tags=["Kaspa addresses"],
+    openapi_extra={"strict_query_params": True},
+)
+async def get_utxo_count_for_address(
+    kaspaAddress: str = Path(description=f"Kaspa address as string e.g. {ADDRESS_EXAMPLE}", regex=REGEX_KASPA_ADDRESS),
+):
+    """
+    Returns the number of open UTXOs for a given kaspa address
+    """
+    try:
+        to_script(kaspaAddress)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Invalid address: {kaspaAddress}")
+
+    count = await _get_utxo_count_from_table(kaspaAddress)
+    if count is None:
+        utxos = await get_utxos([kaspaAddress])
+        count = len([u for u in utxos if u["address"] == kaspaAddress])
+
+    return {"count": count}
 
 
 async def get_utxos(addresses):
@@ -139,6 +168,26 @@ async def get_utxos(addresses):
     return utxos["entries"]
 
 
+async def _ensure_table_known(session) -> bool:
+    """Checks and caches whether script_utxo_counts exists. Returns table existence."""
+    global _utxo_count_table_exists
+    if _utxo_count_table_exists is None:
+        result = await session.execute(
+            text(
+                "SELECT EXISTS ("
+                "SELECT FROM information_schema.tables "
+                "WHERE table_schema = 'public' AND table_name = 'script_utxo_counts'"
+                ");"
+            )
+        )
+        _utxo_count_table_exists = result.scalar()
+        if _utxo_count_table_exists:
+            _logger.info("script_utxo_counts helper table detected")
+        else:
+            _logger.info("script_utxo_counts helper table NOT found – UTXO count limiting disabled")
+    return _utxo_count_table_exists
+
+
 async def _get_over_limit_addresses(addresses: list[str]) -> set[str]:
     """
     Returns the subset of *addresses* whose UTXO count exceeds SCRIPTS_UTXOS_LIMIT
@@ -148,24 +197,8 @@ async def _get_over_limit_addresses(addresses: list[str]) -> set[str]:
     if not os.getenv("SQL_URI"):
         return set()
 
-    global _utxo_count_table_exists
     async with async_session() as s:
-        if _utxo_count_table_exists is None:
-            result = await s.execute(
-                text(
-                    "SELECT EXISTS ("
-                    "SELECT FROM information_schema.tables "
-                    "WHERE table_schema = 'public' AND table_name = 'script_utxo_counts'"
-                    ");"
-                )
-            )
-            _utxo_count_table_exists = result.scalar()
-            if _utxo_count_table_exists:
-                _logger.info("script_utxo_counts helper table detected")
-            else:
-                _logger.info("script_utxo_counts helper table NOT found – UTXO count limiting disabled")
-
-        if not _utxo_count_table_exists:
+        if not await _ensure_table_known(s):
             return set()
 
         if USE_SCRIPT_FOR_ADDRESS:
@@ -184,3 +217,30 @@ async def _get_over_limit_addresses(addresses: list[str]) -> set[str]:
                 )
             )
             return set(result.scalars())
+
+
+async def _get_utxo_count_from_table(kaspaAddress: str) -> int | None:
+    """
+    Returns the UTXO count for *kaspaAddress* from the helper table,
+    or None if the table is absent or has no row for the address.
+    """
+    if not os.getenv("SQL_URI"):
+        return None
+
+    async with async_session() as s:
+        if not await _ensure_table_known(s):
+            return None
+
+        if USE_SCRIPT_FOR_ADDRESS:
+            result = await s.execute(
+                select(ScriptUtxoCount.count).where(
+                    ScriptUtxoCount.script_public_key == to_script(kaspaAddress)
+                )
+            )
+        else:
+            result = await s.execute(
+                select(ScriptUtxoCount.count).where(
+                    ScriptUtxoCount.script_public_key_address == kaspaAddress
+                )
+            )
+        return result.scalar()

--- a/models/ScriptUtxoCount.py
+++ b/models/ScriptUtxoCount.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, BigInteger, String
+
+from dbsession import Base
+from models.type_decorators.HexColumn import HexColumn
+
+
+class ScriptUtxoCount(Base):
+    __tablename__ = "script_utxo_counts"
+    script_public_key = Column(HexColumn, primary_key=True)
+    script_public_key_address = Column(String)
+    count = Column(BigInteger)


### PR DESCRIPTION
The limit-utxos branch adds a UTXO limit mechanism to the /addresses/{address}/utxos endpoint. When an address holds too many UTXOs (exceeding a configurable SCRIPTS_UTXOS_LIMIT threshold), the endpoint returns an empty list instead of an HTTP error (or fetching a massive payload), and logs the over-limit address. It also introduces a new /addresses/{address}/utxos/count endpoint so callers can still retrieve the UTXO count even when the full list is withheld. Cache-control TTLs are applied accordingly.