### PR TITLE
TransactionTypes: don't double-prefix already-prefixed addresses

### DIFF
--- a/models/TransactionTypes.py
+++ b/models/TransactionTypes.py
@@ -30,6 +30,8 @@ class TransactionInput:
         self.previous_outpoint_script = bytea_to_hex(self.previous_outpoint_script)
         if self.previous_outpoint_script:
             self.previous_outpoint_address = to_address(ADDRESS_PREFIX, self.previous_outpoint_script)
+        elif self.previous_outpoint_address and not self.previous_outpoint_address.startswith(ADDRESS_PREFIX + ":"):
+            self.previous_outpoint_address = ADDRESS_PREFIX + ":" + self.previous_outpoint_address
 
 
 @dataclass
@@ -43,7 +45,7 @@ class TransactionOutput:
 
     def __post_init__(self):
         self.script_public_key = bytea_to_hex(self.script_public_key)
-        if self.script_public_key_address:
+        if self.script_public_key_address and not self.script_public_key_address.startswith(ADDRESS_PREFIX + ":"):
             self.script_public_key_address = ADDRESS_PREFIX + ":" + self.script_public_key_address
         if self.script_public_key:
             self.script_public_key_type = get_public_key_type(self.script_public_key)


### PR DESCRIPTION
The `script_public_key_address` handling in `TransactionOutput.__post_init__` prepends `ADDRESS_PREFIX + ":"` unconditionally when the field is set. In practice the address sometimes comes back from the DB with the prefix already present (depending on which resolution path was hit in `get_transactions.py`), and you end up with something like `kaspa:kaspa:qz0d...`.

Two-line change: wrap the prepend with a `startswith` guard so it only fires when the prefix is actually missing. Also applied the same treatment to `TransactionInput.previous_outpoint_address`, which has the same shape but currently isn't getting prefixed at all if only the bare address comes through.