### PR TITLE
KaspadThread.request: honor the timeout parameter

### DIFF
--- a/kaspad/KaspadThread.py
+++ b/kaspad/KaspadThread.py
@@ -59,7 +59,7 @@ class KaspadThread(object):
     async def request(self, command, params=None, wait_for_response=True, timeout=120):
         if wait_for_response:
             try:
-                async for resp in self.stub.MessageStream(self.yield_cmd(command, params), timeout=120):
+                async for resp in self.stub.MessageStream(self.yield_cmd(command, params), timeout=timeout):
                     self.__queue.put_nowait("done")
                     return json_format.MessageToDict(resp, always_print_fields_with_no_presence=True)
             except grpc.aio._call.AioRpcError as e:


### PR DESCRIPTION
`KaspadThread.request` takes a `timeout` parameter but the actual call to `MessageStream` is wired to a hardcoded `timeout=120`. So `kaspad_client.request("getInfo", timeout=5)` still waits 120 seconds on a slow stream before raising.

In practice this means a single hung gRPC stream pins a worker for two full minutes. With a small number of gunicorn workers, a handful of such hangs is enough to stall the whole process — we hit this consistently when a kaspad node started getting slow under load.

One-character fix: `timeout=120` → `timeout=timeout`. Default of the parameter is left at 120 for backward compatibility, so existing callers that don't pass a timeout behave exactly as before.