### PR TITLE
KaspadMultiClient: don't crash on AttributeError when no kaspad is synced

### DIFF
--- a/kaspad/KaspadMultiClient.py
+++ b/kaspad/KaspadMultiClient.py
@@ -15,6 +15,7 @@ class KaspadMultiClient(object):
         for k in self.kaspads:
             if k.is_utxo_indexed and k.is_synced:
                 return k
+        return None
 
     async def initialize_all(self):
         tasks = [asyncio.create_task(k.ping()) for k in self.kaspads]
@@ -23,11 +24,23 @@ class KaspadMultiClient(object):
             await t
 
     async def request(self, command, params=None, timeout=5):
+        client = self.__get_kaspad()
+        if client is None:
+            await self.initialize_all()
+            client = self.__get_kaspad()
+            if client is None:
+                raise KaspadCommunicationError("no synced kaspad available")
         try:
-            return await self.__get_kaspad().request(command, params, timeout=timeout)
+            return await client.request(command, params, timeout=timeout)
         except KaspadCommunicationError:
             await self.initialize_all()
-            return await self.__get_kaspad().request(command, params, timeout=timeout)
+            client = self.__get_kaspad()
+            if client is None:
+                raise KaspadCommunicationError("no synced kaspad available after re-init")
+            return await client.request(command, params, timeout=timeout)
 
     async def notify(self, command, params, callback):
-        return await self.__get_kaspad().notify(command, params, callback)
+        client = self.__get_kaspad()
+        if client is None:
+            raise KaspadCommunicationError("no synced kaspad available")
+        return await client.notify(command, params, callback)


### PR DESCRIPTION
`__get_kaspad()` returns `None` implicitly when no client is currently both synced and UTXO-indexed. The callers in `request()` and `notify()` call `.request()` / `.notify()` on that None, which surfaces as `AttributeError: 'NoneType' object has no attribute 'request'` on the worker.

This is most visible right at process start before the background tasks have managed to mark a kaspad as synced — a short window where any incoming request crashes the worker with an unhelpful traceback. Also happens if every configured kaspad host falls behind at once.

Two things in this PR:

1. `__get_kaspad` gets an explicit `return None` so the implicit fall-through stops looking like an oversight.
2. `request()` and `notify()` now check for None. `request()` additionally tries `initialize_all()` once and re-checks before giving up — gives the system a chance to recover during the cold-start window. If it's still None, we raise `KaspadCommunicationError` with a clear message instead of an `AttributeError`.