### PR TITLE
get_virtual_chain_blue_score: serve from background-refreshed cache

### DIFF
--- a/endpoints/get_virtual_chain_blue_score.py
+++ b/endpoints/get_virtual_chain_blue_score.py
@@ -17,11 +17,9 @@ class BlueScoreResponse(BaseModel):
     blueScore: int = 260890
 
 
-@app.get("/info/virtual-chain-blue-score", response_model=BlueScoreResponse, tags=["Kaspa network info"])
-async def get_virtual_selected_parent_blue_score():
-    """
-    Returns the blue score of the sink
-    """
+async def _fetch_sink_blue_score_from_node():
+    """Fetch the sink blue score directly from the node. Used by the endpoint
+    fallback path and by the background refresh loop."""
     rpc_client = await kaspad_rpc_client()
     if rpc_client:
         return await wait_for(rpc_client.get_sink_blue_score(), 10)
@@ -32,6 +30,19 @@ async def get_virtual_selected_parent_blue_score():
         return resp["getSinkBlueScoreResponse"]
 
 
+@app.get("/info/virtual-chain-blue-score", response_model=BlueScoreResponse, tags=["Kaspa network info"])
+async def get_virtual_selected_parent_blue_score():
+    """
+    Returns the blue score of the sink. Served from a background-refreshed
+    cache (updated every 5s); falls back to a live fetch only if the cache
+    hasn't been populated yet.
+    """
+    cached = current_blue_score_data.get("blue_score")
+    if cached:
+        return {"blueScore": cached}
+    return await _fetch_sink_blue_score_from_node()
+
+
 @app.on_event("startup")
 async def update_blue_score():
     global current_blue_score_data
@@ -39,7 +50,7 @@ async def update_blue_score():
     async def loop():
         while True:
             try:
-                blue_score = await get_virtual_selected_parent_blue_score()
+                blue_score = await _fetch_sink_blue_score_from_node()
                 current_blue_score_data["blue_score"] = int(blue_score["blueScore"])
                 logging.debug(f"Updated current_blue_score: {current_blue_score_data['blue_score']}")
             except Exception as e:


### PR DESCRIPTION
The `/info/virtual-chain-blue-score` endpoint hits kaspad on every request even though the background loop right below it is already updating `current_blue_score_data` every 5s. The cached value just wasn't being read.

Small refactor:

- `_fetch_sink_blue_score_from_node()` helper holds the actual node-fetching logic
- The endpoint reads from `current_blue_score_data` and only falls back to a live fetch if the cache hasn't been populated yet (cold start, before the first loop iteration)
- The background loop calls the helper directly. The previous code called the endpoint function from the loop — works today, but would now read the cached value back from itself and stay stuck at zero forever.

Trade-off: callers can see a value up to 5 seconds old. For `blueScore` that's negligible (blocks advance ~10/s) but happy to make the staleness configurable, or leave a live-fetch query param for callers who need the freshest value.