### PR TITLE
Add ORJSON responses and an optional per-worker concurrency limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ greenlet = "^3.2.4"
 sqlalchemy = "^2.0"
 psycopg = {version = "^3.2.10", extras = ["binary", "pool", "async"]}
 sqlalchemy-utils = "^0.42.0"
+orjson = ">=3.9"
+uvloop = ">=0.19"
+httptools = ">=0.6"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.6.9"

--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ import fastapi.logger
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.responses import ORJSONResponse
 from pydantic import BaseModel
 from sqlalchemy import text
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -28,6 +29,7 @@ _logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="Kaspa REST-API server",
+    default_response_class=ORJSONResponse,
     description="REST-API server supporting block, tx and address search, using Kaspad and the indexer db.\n\n"
     "[https://github.com/kaspa-ng/kaspa-rest-server](https://github.com/kaspa-ng/kaspa-rest-server)",
     version=os.getenv("VERSION") or "dev",
@@ -46,7 +48,32 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
         return response
 
 
+class ConcurrencyLimitMiddleware:
+    """
+    Caps the number of in-flight HTTP requests per worker via a semaphore.
+    Set MAX_CONCURRENT_REQUESTS=0 (the default) to disable. Health, ping
+    and blue-score endpoints bypass the limit so monitoring stays responsive
+    even when the worker is at saturation.
+    """
+
+    BYPASS_PATHS = frozenset({"/info/health", "/info/virtual-chain-blue-score", "/ping"})
+
+    def __init__(self, app, max_concurrent: int = 0):
+        self.app = app
+        self._semaphore = asyncio.Semaphore(max_concurrent) if max_concurrent > 0 else None
+
+    async def __call__(self, scope, receive, send):
+        if self._semaphore is None or scope["type"] != "http" or scope.get("path", "") in self.BYPASS_PATHS:
+            await self.app(scope, receive, send)
+            return
+        async with self._semaphore:
+            await self.app(scope, receive, send)
+
+
 app.add_middleware(GZipMiddleware, minimum_size=500)
+app.add_middleware(
+    ConcurrencyLimitMiddleware, max_concurrent=int(os.getenv("MAX_CONCURRENT_REQUESTS", "0"))
+)
 app.add_middleware(LimitUploadSize, max_upload_size=200_000)  # ~1MB
 
 app.add_middleware(


### PR DESCRIPTION
Two small additions for high-throughput deployments. Both can ship independently if you'd rather split — happy to do that.

**ORJSON responses.** Adds `orjson` to deps and sets it as FastAPI's `default_response_class`. No interface change — same response types, just a faster serializer. The biggest win is on endpoints that return large transaction or block lists.

**Optional per-worker concurrency limit.** Adds `ConcurrencyLimitMiddleware`, a small ASGI semaphore that caps the number of in-flight requests per worker. Controlled by `MAX_CONCURRENT_REQUESTS` env var, **default 0 which disables it entirely** — so this PR is a no-op for existing deployments. `/info/health`, `/info/virtual-chain-blue-score` and `/ping` bypass the limit so health checks stay responsive even at saturation.

Why bother: without the cap, an overwhelmed worker keeps spawning request coroutines faster than it can clear them, and the event loop ends up spending most of its CPU on scheduling rather than actually serving requests. The semaphore makes excess requests queue for a slot. We run this at `MAX_CONCURRENT_REQUESTS=15` and it noticeably stabilizes p99 under load.

`uvloop` and `httptools` are also added to deps — uvicorn picks them up automatically if installed, no behavior change otherwise.