### PR TITLE
fix: prevent AttributeError when no kaspad is synced

### DIFF
--- a/kaspad/KaspadMultiClient.py
+++ b/kaspad/KaspadMultiClient.py
@@ -15,6 +15,7 @@ class KaspadMultiClient(object):
         for k in self.kaspads:
             if k.is_utxo_indexed and k.is_synced:
                 return k
+        return None
 
     async def initialize_all(self):
         tasks = [asyncio.create_task(k.ping()) for k in self.kaspads]
@@ -23,11 +24,24 @@ class KaspadMultiClient(object):
             await t
 
     async def request(self, command, params=None, timeout=5):
+        client = self.__get_kaspad()
+        if client is None:
+            await self.initialize_all()
+            client = self.__get_kaspad()
+            if client is None:
+                raise KaspadCommunicationError("No synced kaspad available")
         try:
-            return await self.__get_kaspad().request(command, params, timeout=timeout)
+            return await client.request(command, params, timeout=timeout)
         except KaspadCommunicationError:
             await self.initialize_all()
-            return await self.__get_kaspad().request(command, params, timeout=timeout)
+            client = self.__get_kaspad()
+            if client is None:
+                raise
+            return await client.request(command, params, timeout=timeout)
 
     async def notify(self, command, params, callback):
-        return await self.__get_kaspad().notify(command, params, callback)
+        client = self.__get_kaspad()
+        if client is None:
+            await self.initialize_all()
+            client = self.__get_kaspad()
+        return await client.notify(command, params, callback)


### PR DESCRIPTION
## Summary
`__get_kaspad()` returns `None` implicitly when no client is currently both synced and UTXO-indexed. The callers in `request()` and `notify()` call `.request()` / `.notify()` on that None, which surfaces as `AttributeError: 'NoneType' object has no attribute 'request'`.

Two things in this PR:

1. `__get_kaspad` gets an explicit `return None` so the implicit fall-through stops looking like an oversight.
2. `request()` and `notify()` now check for None and call `initialize_all()` before retrying. `request()` raises a clear `KaspadCommunicationError` if still None after re-initialization.

Fixes kaspa-ng/kaspa-rest-server#121